### PR TITLE
recoverTo 메소드 추가

### DIFF
--- a/contracts/ERC20TokenWithNegativeNumber.sol
+++ b/contracts/ERC20TokenWithNegativeNumber.sol
@@ -22,6 +22,8 @@ contract ERC20TokenWithNegativeNumber is Ownable, Pausable{
   event Recover(address indexed from, address indexed to, int256 value);
 
   constructor(string name, string symbol, uint8 decimals, int256 initialSupply) public {
+    require(initialSupply > 0);
+
     _name = name;
     _symbol = symbol;
     _decimals = decimals;
@@ -170,6 +172,7 @@ contract ERC20TokenWithNegativeNumber is Ownable, Pausable{
      */
   function _transfer(address from, address to, int256 value) internal {
     require(to != address(0));
+    require(value > 0);
     require(_balances[from].sub(value) >= 0);
 
     _balances[from] = _balances[from].sub(value);
@@ -179,6 +182,7 @@ contract ERC20TokenWithNegativeNumber is Ownable, Pausable{
 
   function _mint(address account, int256 value) internal {
     require(account != address(0));
+    require(value > 0);
 
     _totalSupply = _totalSupply.add(value);
     _balances[account] = _balances[account].add(value);
@@ -203,6 +207,7 @@ contract ERC20TokenWithNegativeNumber is Ownable, Pausable{
    */
   function _burn(address account, int256 value) internal {
     require(account != address(0));
+    require(value > 0);
 
     _balances[account] = _balances[account].sub(value);
     _totalSupply = _totalSupply.sub(value);
@@ -248,6 +253,7 @@ contract ERC20TokenWithNegativeNumber is Ownable, Pausable{
   function _recover(address from, address to, int256 value) internal {
     require(from != address(0));
     require(to != address(0));
+    require(value > 0);
 
     _balances[from] = _balances[from].sub(value);
     _balances[to] = _balances[to].add(value);

--- a/contracts/ERC20TokenWithNegativeNumber.sol
+++ b/contracts/ERC20TokenWithNegativeNumber.sol
@@ -241,6 +241,10 @@ contract ERC20TokenWithNegativeNumber is Ownable, Pausable{
     _recover(from, msg.sender, value);
   }
 
+  function recoverTo(address from, address to, int256 value) onlyOwner whenNotPaused public {
+    _recover(from, to, value);
+  }
+
   function _recover(address from, address to, int256 value) internal {
     require(from != address(0));
     require(to != address(0));

--- a/test/ERC20TokenWithNagativeNumber.test.js
+++ b/test/ERC20TokenWithNagativeNumber.test.js
@@ -22,6 +22,14 @@ contract('ERC20TokenWithNegativeNumber', (accounts) => {
       tokenInstance = await ERC20TokenNN.new('NAME', 'SYMBOL', decimals, initialSupply);
     });
 
+    it('should fail if initialSupply is negative number ', async () => {
+      const negativeInitialSupply = new web3.utils.BN(web3.utils.toWei('-1000'));
+      await truffleAssert.fails(
+        ERC20TokenNN.new('NAME', 'SYMBOL', decimals, negativeInitialSupply),
+        truffleAssert.ErrorType.REVERT,
+      );
+    });
+
     it('owner should have all the initialSupply', async () => {
       const balance = await tokenInstance.balanceOf.call(owner);
 
@@ -119,6 +127,15 @@ contract('ERC20TokenWithNegativeNumber', (accounts) => {
         truffleAssert.ErrorType.REVERT,
       );
     });
+
+    it('should fail when trying to call with negative value', async () => {
+      const minusValue = new web3.utils.BN(web3.utils.toWei('-1', 'ether'));
+
+      await truffleAssert.fails(
+        tokenInstance.transfer(recipient, minusValue),
+        truffleAssert.ErrorType.REVERT,
+      );
+    });
   });
 
   describe('approve', async () => {
@@ -182,6 +199,15 @@ contract('ERC20TokenWithNegativeNumber', (accounts) => {
 
       await truffleAssert.fails(
         tokenInstance.approve(spender, spendAmount, { from: owner }),
+        truffleAssert.ErrorType.REVERT,
+      );
+    });
+
+    it('should fail when trying to call with negative value', async () => {
+      const minusValue = new web3.utils.BN(web3.utils.toWei('-1', 'ether'));
+
+      await truffleAssert.fails(
+        tokenInstance.approve(spender, minusValue, { from: owner }),
         truffleAssert.ErrorType.REVERT,
       );
     });
@@ -315,6 +341,14 @@ contract('ERC20TokenWithNegativeNumber', (accounts) => {
       );
     });
 
+    it('should fail when trying to call with negative value', async () => {
+      const minusValue = new web3.utils.BN(web3.utils.toWei('-100', 'ether'));
+
+      await truffleAssert.fails(
+        tokenInstance.burn(minusValue, { from: owner }),
+        truffleAssert.ErrorType.REVERT,
+      );
+    });
   });
 
   describe('burnFrom', async () => {
@@ -392,6 +426,7 @@ contract('ERC20TokenWithNegativeNumber', (accounts) => {
         truffleAssert.ErrorType.REVERT,
       );
     });
+
     it('should fail when chain paused', async () => {
       await tokenInstance.approve(owner, allowedAmount, { from: burner });
 
@@ -475,6 +510,15 @@ contract('ERC20TokenWithNegativeNumber', (accounts) => {
 
       await truffleAssert.fails(
         tokenInstance.recover(recipient, transferAmount, { from: holder }),
+        truffleAssert.ErrorType.REVERT,
+      );
+    });
+
+    it('should fail when trying to call with negative value', async () => {
+      const minusValue = new web3.utils.BN(web3.utils.toWei('-100', 'ether'));
+
+      await truffleAssert.fails(
+        tokenInstance.recover(holder, minusValue, { from: owner }),
         truffleAssert.ErrorType.REVERT,
       );
     });


### PR DESCRIPTION
## 작업 내용
-  `recover`는 `owner`에게만 전송할 수 있기 때문에 또 다른 누군가에게 전송할 수 있는 기능 추가. (ex 보관용 EOA로 보낸다)
- `int256`을 사용하기에 아래의 기능들에는 0 초과인 value만 받을 수 있도록 조치
  - `transfer` ( `transferFrom` )
  - `approve` (조치되어있음)
  - `burn` ( `burnFrom` )
  - `mint`
  - `recover` ( `recoverTo` )
- `mint`에 대한 TC가 누락되어서 추가
